### PR TITLE
Correct dependency

### DIFF
--- a/files/Rakefile.erb
+++ b/files/Rakefile.erb
@@ -30,7 +30,7 @@ Motion::Project::App.setup do |app|
 
   app.gradle do
     # Google's networking API for Android
-    dependency "com.mcxiaoke.volley", :artifact => "library", :version => "1.0.10"
+    dependency 'com.mcxiaoke.volley:library:1.0.19'
   end
 
 end


### PR DESCRIPTION
Using the "old" dependency give this error when starting a new project

``` shell
~/Desktop/myapp  rake gradle:install
fatal: Not a git repository (or any of the parent directories): .git
rake aborted!
ArgumentError: wrong number of arguments (2 for 1)
/Users/benjamin/Desktop/myapp/Rakefile:33:in `block (2 levels) in <top (required)>'
/Users/benjamin/Desktop/myapp/Rakefile:31:in `block in <top (required)>'
/Library/RubyMotion/lib/motion/project/config.rb:121:in `call'
/Library/RubyMotion/lib/motion/project/config.rb:121:in `block in setup'
/Library/RubyMotion/lib/motion/project/config.rb:121:in `each'
/Library/RubyMotion/lib/motion/project/config.rb:121:in `setup'
/Library/RubyMotion/lib/motion/project/app.rb:66:in `config'
Tasks: TOP => gradle:install
(See full trace by running task with --trace)
```

This PR change the way the dependency is written
